### PR TITLE
fix idempotency

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,22 +1,26 @@
+version: "2"
+
 linters:
-    enable-all: true
+    default: all
     disable:
+        - cyclop
+        - err113
         - depguard
         - exhaustruct
-        - exportloopref
         - funlen
         - godox
+        - godot
         - mnd
         - varnamelen
         - forbidigo
-        - gocognit
-        - gocyclo
-        - cyclop
-        - err113
-        - maintidx
-        - tagliatelle # prefer snake_case in json fields
+        - tagliatelle
+        - nlreturn
         - gochecknoglobals
-        - gochecknoinits
-        # would be nice to have but too many tests depend on environment variables, which is not allowed for t.Parallel()
-        - paralleltest
-        - nlreturn # find this annoying more than useful
+
+    settings:
+        cyclop:
+            max-complexity: 15
+        revive:
+            rules:
+                - name: "exported"
+                  disabled: true

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,6 +24,7 @@ var (
 	scanner = facter.Scanner{}
 )
 
+//nolint:gochecknoinits
 func init() {
 	// Define flags
 	flag.StringVar(&outputPath, "output", "", "path to write the report")

--- a/pkg/ephem/swap_test.go
+++ b/pkg/ephem/swap_test.go
@@ -24,6 +24,7 @@ foo bar baz
 )
 
 func TestReadSwapFile(t *testing.T) {
+	t.Parallel()
 	as := require.New(t)
 
 	_, err := ephem.ReadSwapFile(strings.NewReader(""))

--- a/pkg/facter/hardware.go
+++ b/pkg/facter/hardware.go
@@ -183,9 +183,10 @@ type Hardware struct {
 }
 
 func compareDevice(a hwinfo.HardwareDevice, b hwinfo.HardwareDevice) int {
-	return int(a.Index - b.Index) //nolint:gosec
+	return int(a.Index - b.Index)
 }
 
+//nolint:gocyclo,maintidx
 func (h *Hardware) add(device hwinfo.HardwareDevice) error {
 	slog.Debug(
 		"hardware.add",
@@ -242,7 +243,7 @@ func (h *Hardware) add(device hwinfo.HardwareDevice) error {
 		}
 
 		// We insert by physical id, as we only want one entry per core.
-		requiredSize := int(cpu.PhysicalID) + 1 //nolint:gosec
+		requiredSize := int(cpu.PhysicalID) + 1
 
 		if len(h.CPU) < requiredSize {
 			newItems := make([]*hwinfo.DetailCPU, requiredSize-len(h.CPU))
@@ -264,7 +265,7 @@ func (h *Hardware) add(device hwinfo.HardwareDevice) error {
 			case a != nil && b == nil:
 				return 1
 			default:
-				return int(a.PhysicalID - b.PhysicalID) //nolint:gosec
+				return int(a.PhysicalID - b.PhysicalID)
 			}
 		})
 

--- a/pkg/facter/smbios.go
+++ b/pkg/facter/smbios.go
@@ -75,6 +75,7 @@ type Smbios struct {
 	System *hwinfo.SmbiosSystem `json:"system,omitempty"`
 }
 
+//nolint:gocyclo
 func (s *Smbios) add(item hwinfo.Smbios) error {
 	slog.Debug("smbios.add", "type", item.SmbiosType())
 

--- a/pkg/hwinfo/detail.go
+++ b/pkg/hwinfo/detail.go
@@ -27,7 +27,6 @@ import (
 //go:generate enumer -type=DetailType -json -transform=snake -trimprefix DetailType -output=./detail_enum_type.go
 type DetailType uint //nolint:recvcheck
 
-//nolint:revive,stylecheck
 const (
 	DetailTypePci DetailType = iota
 	DetailTypeUsb

--- a/pkg/hwinfo/detail_cpu.go
+++ b/pkg/hwinfo/detail_cpu.go
@@ -62,10 +62,10 @@ type DetailCPU struct {
 	Bugs            []string `json:"bugs,omitempty"`
 	PowerManagement []string `json:"power_management,omitempty"`
 
-	Bogo  float64 `json:"bogo"`
-	Cache uint32  `json:"cache,omitempty"`
-	Units uint32  `json:"units,omitempty"`
-	Clock uint    `json:"-"`
+	Bogo  uint32 `json:"bogo"`
+	Cache uint32 `json:"cache,omitempty"`
+	Units uint32 `json:"units,omitempty"`
+	Clock uint   `json:"-"`
 
 	// x86 only fields
 	PhysicalID     uint16       `json:"physical_id"`
@@ -112,7 +112,9 @@ func NewDetailCPU(cpu C.hd_detail_cpu_t) (*DetailCPU, error) {
 		PowerManagement: ReadStringList(data.power_management),
 
 		Clock: uint(data.clock),
-		Bogo:  float64(data.bogo),
+
+		// Bogo is reported as a float, but that value isn't stable so we truncate to an int.
+		Bogo:  uint32(data.bogo),
 		Cache: uint32(data.cache),
 		Units: uint32(data.units),
 

--- a/pkg/hwinfo/detail_isa_pnp_dev.go
+++ b/pkg/hwinfo/detail_isa_pnp_dev.go
@@ -26,6 +26,7 @@ func NewIsaPnpResource(res *C.isapnp_res_t) *IsaPnpResource {
 	if res == nil {
 		return nil
 	}
+
 	return &IsaPnpResource{
 		Length: int(res.len),
 		Type:   int(res._type),

--- a/pkg/hwinfo/detail_pci.go
+++ b/pkg/hwinfo/detail_pci.go
@@ -46,7 +46,7 @@ type DetailPci struct {
 	HeaderType   uint32 `json:"header_type"`   // PCI_HEADER_TYPE
 	SecondaryBus uint32 `json:"secondary_bus"` // > 0 for PCI & CB bridges
 
-	Irq uint16 `json:"irq"` // used irq if any
+	Irq uint16 `json:"-"` // used irq if any
 	// Programming Interface Byte: a read-only register that specifies a register-level programming interface for the
 	// device.
 	ProgIf uint16 `json:"prog_if"`

--- a/pkg/hwinfo/detail_sys.go
+++ b/pkg/hwinfo/detail_sys.go
@@ -23,6 +23,7 @@ func (d DetailSys) DetailType() DetailType {
 
 func NewDetailSys(sys C.hd_detail_sys_t) (*DetailSys, error) {
 	data := sys.data
+
 	return &DetailSys{
 		Type:       DetailTypeSys,
 		SystemType: C.GoString(data.system_type),

--- a/pkg/hwinfo/driver_info.go
+++ b/pkg/hwinfo/driver_info.go
@@ -63,7 +63,7 @@ func NewDriverInfo(info *C.driver_info_t) (DriverInfo, error) {
 		result, err = NewDriverInfoIsdn(C.driver_info_get_isdn(info)), nil
 	case DriverInfoTypeX11:
 		result, err = NewDriverInfoX11(C.driver_info_get_x11(info)), nil
-	default:
+	case DriverInfoTypeAny:
 		err = errors.New("unknown driver info type")
 	}
 

--- a/pkg/hwinfo/hardware.go
+++ b/pkg/hwinfo/hardware.go
@@ -472,10 +472,10 @@ type HardwareDevice struct {
 	// UnixDeviceName is a path to a device file used to access this hardware.
 	// Normally something below /dev.
 	// For network interfaces, this is the interface name.
-	UnixDeviceName string `json:"unix_device_name,omitempty"`
+	UnixDeviceName string `json:"-"`
 
 	// UnixDeviceNumber represents the device type and number according to sysfs.
-	UnixDeviceNumber *DeviceNumber `json:"unix_device_number,omitempty"`
+	UnixDeviceNumber *DeviceNumber `json:"-"`
 
 	// UnixDeviceNames is a list of device names which can be used to access this hardware.
 	// Normally something below /dev.
@@ -489,7 +489,7 @@ type HardwareDevice struct {
 	UnixDeviceName2 string `json:"unix_device_name2,omitempty"`
 
 	// UnixDeviceNumber2 is an alternative device type and number according to sysfs.
-	UnixDeviceNumber2 *DeviceNumber `json:"unix_device_number2,omitempty"`
+	UnixDeviceNumber2 *DeviceNumber `json:"-"`
 
 	// RomID represents a BIOS/PROM id.
 	// Where appropriate, this is a special BIOS/PROM id (e.g. "0x80" for the first harddisk on Intel-PCs).

--- a/pkg/hwinfo/hardware.go
+++ b/pkg/hwinfo/hardware.go
@@ -19,7 +19,6 @@ import (
 //go:generate enumer -type=ProbeFeature -json -transform=snake -trimprefix ProbeFeature -output=./hardware_enum_probe_feature.go
 type ProbeFeature uint //nolint:recvcheck
 
-//nolint:revive,stylecheck
 const (
 	ProbeFeatureMemory ProbeFeature = iota + 1
 	ProbeFeaturePci
@@ -123,7 +122,6 @@ const (
 //go:generate enumer -type=HardwareClass -json -transform=snake -trimprefix HardwareClass -output=./hardware_enum_hardware_class.go
 type HardwareClass uint //nolint:recvcheck
 
-//nolint:revive,stylecheck
 const (
 	HardwareClassNone HardwareClass = iota
 	HardwareClassSystem
@@ -334,6 +332,7 @@ func NewDeviceNumber(num C.hd_dev_num_t) *DeviceNumber {
 	if result.IsEmpty() {
 		return nil
 	}
+
 	return &result
 }
 
@@ -586,6 +585,7 @@ func NewHardwareDevice(hd *C.hd_t, ephemeral bool) (*HardwareDevice, error) {
 	}
 
 	var hwClassList []HardwareClass
+
 	for i := HardwareClassSystem; i < HardwareClassAll; i++ {
 		if C.hd_is_hw_class(hd, C.hd_hw_item_t(i)) == 1 {
 			hwClassList = append(hwClassList, i)

--- a/pkg/hwinfo/hwinfo.go
+++ b/pkg/hwinfo/hwinfo.go
@@ -27,6 +27,7 @@ func excludeDevice(item *HardwareDevice) bool {
 			}
 		}
 	}
+
 	return false
 }
 
@@ -46,9 +47,11 @@ func Scan(probes []ProbeFeature, ephemeral bool) ([]Smbios, []HardwareDevice, er
 
 	// scan
 	C.hd_scan(data)
+
 	defer C.hd_free_hd_data(data)
 
 	var smbiosItems []Smbios
+
 	for sm := data.smbios; sm != nil; sm = C.hd_smbios_next(sm) {
 		item, err := NewSmbios(sm)
 		if err != nil {
@@ -56,11 +59,15 @@ func Scan(probes []ProbeFeature, ephemeral bool) ([]Smbios, []HardwareDevice, er
 		} else if item == nil {
 			continue
 		}
+
 		smbiosItems = append(smbiosItems, item)
 	}
 
-	var hardwareItems []HardwareDevice
-	var deviceIdx uint16
+	var (
+		deviceIdx     uint16
+		hardwareItems []HardwareDevice
+	)
+
 	for hd := data.hd; hd != nil; hd = hd.next {
 		item, err := NewHardwareDevice(hd, ephemeral)
 		if err != nil {

--- a/pkg/hwinfo/id.go
+++ b/pkg/hwinfo/id.go
@@ -44,7 +44,6 @@ func (i ID) MarshalJSON() ([]byte, error) {
 	)
 
 	switch i.Type {
-
 	case IDTagSpecial:
 		b, err = json.Marshal(i.Name)
 
@@ -91,6 +90,7 @@ func NewID(id C.hd_id_t) *ID {
 	if result.IsEmpty() {
 		return nil
 	}
+
 	return &result
 }
 

--- a/pkg/hwinfo/resource.go
+++ b/pkg/hwinfo/resource.go
@@ -109,7 +109,8 @@ func NewResources(hd *C.hd_t) ([]Resource, error) {
 		if err != nil {
 			return nil, err
 		}
-		if resource == nil {
+		if resource == nil || resource.ResourceType() == ResourceTypeMem {
+			// phys_mem is stable, `mem` is not so, we filter it out.
 			continue
 		}
 		result = append(result, resource)

--- a/pkg/hwinfo/resource.go
+++ b/pkg/hwinfo/resource.go
@@ -95,7 +95,7 @@ func NewResource(res *C.hd_res_t) (Resource, error) {
 		// this is the link status of a network interface and can change when we plug/unplug a cable
 	case ResourceTypeWlan:
 		result, err = NewResourceWlan(res, resourceType)
-	default:
+	case ResourceTypeAny:
 		err = fmt.Errorf("unexpected resource type: %v", resourceType)
 	}
 
@@ -104,16 +104,18 @@ func NewResource(res *C.hd_res_t) (Resource, error) {
 
 func NewResources(hd *C.hd_t) ([]Resource, error) {
 	var result []Resource
+
 	for res := hd.res; res != nil; res = C.hd_res_next(res) {
 		resource, err := NewResource(res)
-
 		if err != nil {
 			return nil, err
 		}
+
 		if resource == nil {
 			continue
 		}
 
+		//nolint:exhaustive
 		switch resource.ResourceType() {
 		// these resources are not stable, so we filter them out
 		case ResourceTypeMem, ResourceTypeIrq:
@@ -122,16 +124,17 @@ func NewResources(hd *C.hd_t) ([]Resource, error) {
 		default:
 			result = append(result, resource)
 		}
-
 	}
 
 	slices.SortFunc(result, func(a, b Resource) int {
 		// We don't really care about a proper ordering for resources, just a stable sort that is reasonably quick.
 		var err error
+
 		jsonA, err := json.Marshal(a)
 		if err != nil {
 			log.Panicf("failed to marshal resource: %s", err)
 		}
+
 		jsonB, err := json.Marshal(b)
 		if err != nil {
 			log.Panicf("failed to marshal resource: %s", err)

--- a/pkg/hwinfo/resource.go
+++ b/pkg/hwinfo/resource.go
@@ -106,14 +106,23 @@ func NewResources(hd *C.hd_t) ([]Resource, error) {
 	var result []Resource
 	for res := hd.res; res != nil; res = C.hd_res_next(res) {
 		resource, err := NewResource(res)
+
 		if err != nil {
 			return nil, err
 		}
-		if resource == nil || resource.ResourceType() == ResourceTypeMem {
-			// phys_mem is stable, `mem` is not so, we filter it out.
+		if resource == nil {
 			continue
 		}
-		result = append(result, resource)
+
+		switch resource.ResourceType() {
+		// these resources are not stable, so we filter them out
+		case ResourceTypeMem, ResourceTypeIrq:
+			continue
+
+		default:
+			result = append(result, resource)
+		}
+
 	}
 
 	slices.SortFunc(result, func(a, b Resource) int {

--- a/pkg/hwinfo/resource_phys_mem.go
+++ b/pkg/hwinfo/resource_phys_mem.go
@@ -33,6 +33,7 @@ func NewResourcePhysicalMemory(res *C.hd_res_t, resType ResourceType) (*Resource
 	}
 
 	physMem := C.hd_res_get_phys_mem(res)
+
 	return &ResourcePhysicalMemory{
 		Type:  resType,
 		Range: uint64(physMem._range),

--- a/pkg/hwinfo/smbios.go
+++ b/pkg/hwinfo/smbios.go
@@ -115,6 +115,7 @@ func NewSmbios(smbios *C.hd_smbios_t) (Smbios, error) {
 		result Smbios
 	)
 
+	//nolint:exhaustive
 	switch SmbiosType(C.hd_smbios_get_type(smbios)) {
 	case SmbiosTypeBios:
 		result, err = NewSmbiosBiosInfo(C.hd_smbios_get_biosinfo(smbios))
@@ -160,9 +161,10 @@ func NewSmbios(smbios *C.hd_smbios_t) (Smbios, error) {
 		result, err = NewSmbiosSlot(C.hd_smbios_get_slot(smbios))
 	case SmbiosTypeSystem:
 		result, err = NewSmbiosSysInfo(C.hd_smbios_get_sysinfo(smbios))
-	default:
-		// We could return Any for this, but it's just noise in the report.
+
+		// We could return Any by default, but it's just noise in the report.
 		// As we support new types, users can run it again.
+	default:
 	}
 
 	return result, err

--- a/pkg/hwinfo/utils.go
+++ b/pkg/hwinfo/utils.go
@@ -12,46 +12,55 @@ func ReadStringList(list *C.str_list_t) []string {
 	for entry := list; entry != nil; entry = entry.next {
 		result = append(result, C.GoString(entry.str))
 	}
+
 	return result
 }
 
 func ReadUint64Array(arr unsafe.Pointer, length int) []uint64 {
 	start := uintptr(arr)
+
 	result := make([]uint64, length)
 	for i := range result {
 		next := start + uintptr(i*C.sizeof_uint64_t)
 		result[i] = *((*uint64)(unsafe.Pointer(next))) //nolint:govet
 	}
+
 	return result
 }
 
 func ReadUintArray(arr unsafe.Pointer, length int) []uint {
 	start := uintptr(arr)
+
 	result := make([]uint, length)
 	for i := range result {
 		next := start + uintptr(i*C.sizeof_uint)
 		result[i] = *((*uint)(unsafe.Pointer(next))) //nolint:govet
 	}
+
 	return result
 }
 
 func ReadIntArray(arr unsafe.Pointer, length int) []int {
 	// TODO see if we can use generics to combine some of these methods
 	start := uintptr(arr)
+
 	result := make([]int, length)
 	for i := range result {
 		next := start + uintptr(i*C.sizeof_uint)
 		result[i] = *((*int)(unsafe.Pointer(next))) //nolint:govet
 	}
+
 	return result
 }
 
 func ReadByteArray(arr unsafe.Pointer, length int) []byte {
 	start := uintptr(arr)
+
 	result := make([]byte, length)
 	for i := range result {
 		next := start + uintptr(i*C.sizeof_uint)
 		result[i] = *((*byte)(unsafe.Pointer(next))) //nolint:govet
 	}
+
 	return result
 }

--- a/pkg/linux/input/input_test.go
+++ b/pkg/linux/input/input_test.go
@@ -53,6 +53,7 @@ B: MSC=10
 )
 
 func TestReadDevices(t *testing.T) {
+	t.Parallel()
 	as := require.New(t)
 	r := io.NopCloser(bytes.NewReader([]byte(devices)))
 
@@ -115,5 +116,5 @@ func TestReadDevices(t *testing.T) {
 		},
 	}
 
-	as.EqualValues(expected, devices)
+	as.Equal(expected, devices)
 }

--- a/pkg/udev/udev.go
+++ b/pkg/udev/udev.go
@@ -252,6 +252,7 @@ func NewUdev(env map[string]string) (*Udev, error) {
 
 	var err error
 
+	//nolint:exhaustive
 	switch result.Bus {
 	case input.BusUsb:
 		if result.Usb, err = NewUdevUsb(env); err != nil {
@@ -324,5 +325,10 @@ func Version() (uint64, error) {
 		return 0, fmt.Errorf("unexpected empty output from udevadm --version: %s", output)
 	}
 
-	return strconv.ParseUint(lines[0], 10, 16)
+	version, err := strconv.ParseUint(lines[0], 10, 16)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse systemd version from udevadm --version: %w", err)
+	}
+
+	return version, nil
 }

--- a/pkg/virt/virt.go
+++ b/pkg/virt/virt.go
@@ -16,7 +16,6 @@ import (
 //go:generate enumer -type=Type -json -text -transform=snake -trimprefix Type -output=./virt_enum_type.go
 type Type int //nolint:recvcheck
 
-//nolint:revive,stylecheck
 const (
 	TypeNone Type = iota
 	TypeKvm


### PR DESCRIPTION
- **fix: truncate bogo mips field in cpu detail**
- **fix: remove irq from the report as it isn't stable.**
- **fix: filter `mem` resource type as it's not stable**
- **fix: filter `irq` resource type as it's not stable**
- **fix: update golangci-lint config to version 2**
- **fix: remove `unix_device_number` from the report as it doesn't appear stable**
