### PR TITLE
Change user-facing URLs to nix-community

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,11 @@ We'd love to hear from you.
 [Clan]: https://clan.lol
 [NixOS configurations]: https://nixos.org/manual/nixos/stable/#sec-configuration-syntax
 [NixOS Hardware]: https://github.com/NixOS/nixos-hardware
-[NixOS Facter Modules]: https://github.com/numtide/nixos-facter-modules
-[NixOS modules]: https://github.com/numtide/nixos-facter-modules
+[NixOS Facter Modules]: https://github.com/nix-community/nixos-facter-modules
+[NixOS modules]: https://github.com/nix-community/nixos-facter-modules
 [nixos-generate-config]: https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/installer/tools/nixos-generate-config.pl
 [Numtide Binary Cache]: https://numtide.cachix.org
-[nixos-facter]: https://github.com/numtide/nixos-facter
+[nixos-facter]: https://github.com/nix-community/nixos-facter
 [nixpkgs]: https://github.com/nixos/nixpkgs
 [docs]: https://nix-community.github.io/nixos-facter
 [GNU GPL v3]: ./LICENSE

--- a/docs/content/getting-started/generate-report.md
+++ b/docs/content/getting-started/generate-report.md
@@ -80,7 +80,7 @@ This will scan your system and produce a JSON-based report in a file named `fact
 [Nix]: https://nixos.org
 [Numtide]: https://numtide.com
 [Numtide Binary Cache]: https://numtide.cachix.org
-[nixos-facter]: https://github.com/numtide/nixos-facter
+[nixos-facter]: https://github.com/nix-community/nixos-facter
 [nixpkgs]: https://github.com/nixos/nixpkgs
 [System Management BIOS]: https://wiki.osdev.org/System_Management_BIOS
-[NixOS Facter Modules]: https://github.com/numtide/nixos-facter-modules
+[NixOS Facter Modules]: https://github.com/nix-community/nixos-facter-modules

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,7 +6,7 @@ site_description: >-
 
 # Repository
 repo_name: numtide/nixos-facter
-repo_url: https://github.com/numtide/nixos-facter
+repo_url: https://github.com/nix-community/nixos-facter
 
 # Copyright
 copyright: >-

--- a/nix/packages/nixos-facter/package.nix
+++ b/nix/packages/nixos-facter/package.nix
@@ -64,7 +64,7 @@ buildGo124Module (final: {
 
   meta = with lib; {
     description = "nixos-facter: declarative nixos-generate-config";
-    homepage = "https://github.com/numtide/nixos-facter";
+    homepage = "https://github.com/nix-community/nixos-facter";
     license = licenses.mit;
     mainProgram = "nixos-facter";
   };


### PR DESCRIPTION
The repo has moved.

I have only changed the user facing ones. Maybe the go files should also be done, but that doesn't seem as pressing.